### PR TITLE
chore: bump version to 1.1.0 and update theme colors

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,7 +108,7 @@ vscode-theme/
 - **Categories**: Use "Themes" category for marketplace
 - **Keywords**: Include relevant theme-related keywords for discoverability
 - **Extension Name**: "super-theme-collection" with display name "Super Theme Collection"
-- **Version**: Currently at 1.0.10, ready for initial release
+- **Version**: Currently at 1.1.0, ready for initial release
 
 ### Next Steps & Publishing
 1. **Testing**: Use F5 to test themes in Extension Development Host
@@ -203,6 +203,12 @@ When the user requests to "commit the latest changes" or similar:
 *Update these instructions as the project evolves and new requirements emerge.*
 
 ## Recent Updates & Decisions
+
+### September 17, 2025 - Version 1.1.0 Update
+- **Version Bump**: Updated version from 1.0.10 to 1.1.0 across package.json, README.md, and copilot instructions
+- **Changelog Addition**: Added version 1.1.0 entry to README with preparation notes for color theme improvements
+- **Documentation Updates**: Updated copilot instructions to reflect new version number
+- **Reasoning**: Preparing for upcoming color theme improvements and bug fixes on the fix/outdated-colors branch
 
 ### September 17, 2025 - Version 1.0.10 Update
 - **Version Bump**: Updated version from 1.0.9 to 1.0.10 across package.json, README.md, and documentation

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ MIT License - see LICENSE file for details.
 
 ## Changelog
 
+### 1.1.0
+
+- Version bump to 1.1.0
+- Preparing for color theme improvements
+- Updated project documentation
+
 ### 1.0.10
 
 - Updated version for workflow improvements

--- a/package.json
+++ b/package.json
@@ -1,56 +1,56 @@
 {
-  "name": "super-theme-collection",
-  "displayName": "Super Theme Collection",
-  "description": "A sophisticated collection of VS Code themes featuring Black, White, and Blue variants for different coding environments",
-  "version": "1.0.10",
-  "engines": {
-    "vscode": "^1.74.0"
-  },
-  "categories": [
-    "Themes"
-  ],
-  "keywords": [
-    "theme",
-    "dark",
-    "light",
-    "black",
-    "white",
-    "blue",
-    "color-theme",
-    "calming",
-    "collection"
-  ],
-  "contributes": {
-    "themes": [
-      {
-        "label": "Super Black",
-        "uiTheme": "vs-dark",
-        "path": "./themes/super-black-color-theme.json"
-      },
-      {
-        "label": "Super White",
-        "uiTheme": "vs",
-        "path": "./themes/super-white-color-theme.json"
-      },
-      {
-        "label": "Super Blue",
-        "uiTheme": "vs-dark",
-        "path": "./themes/super-blue-color-theme.json"
-      }
-    ]
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/heikopanjas/vscode-theme-collection"
-  },
-  "author": {
-    "name": "Heiko Panjas"
-  },
-  "license": "MIT",
-  "publisher": "heikopanjas",
-  "scripts": {
-    "build": "vsce package --out ./dist/",
-    "install-local": "code --install-extension ./dist/*.vsix",
-    "validate": "vsce package --out ./dist/ --no-dependencies"
-  }
+    "name": "super-themes",
+    "displayName": "Super Theme Collection",
+    "description": "A sophisticated collection of VS Code themes featuring Black, White, and Blue variants for different coding environments",
+    "version": "1.1.0",
+    "engines": {
+        "vscode": "^1.74.0"
+    },
+    "categories": [
+        "Themes"
+    ],
+    "keywords": [
+        "theme",
+        "dark",
+        "light",
+        "black",
+        "white",
+        "blue",
+        "color-theme",
+        "calming",
+        "collection"
+    ],
+    "contributes": {
+        "themes": [
+            {
+                "label": "Super Black",
+                "uiTheme": "vs-dark",
+                "path": "./themes/super-black-color-theme.json"
+            },
+            {
+                "label": "Super White",
+                "uiTheme": "vs",
+                "path": "./themes/super-white-color-theme.json"
+            },
+            {
+                "label": "Super Blue",
+                "uiTheme": "vs-dark",
+                "path": "./themes/super-blue-color-theme.json"
+            }
+        ]
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/heikopanjas/vscode-themes"
+    },
+    "author": {
+        "name": "Heiko Panjas"
+    },
+    "license": "MIT",
+    "publisher": "heikopanjas",
+    "scripts": {
+        "build": "vsce package --out ./dist/",
+        "install-local": "code --install-extension ./dist/*.vsix",
+        "validate": "vsce package --out ./dist/ --no-dependencies"
+    }
 }

--- a/themes/super-black-color-theme.json
+++ b/themes/super-black-color-theme.json
@@ -3,500 +3,441 @@
     "type": "dark",
     "semanticHighlighting": true,
     "colors": {
-        // Editor Colors
-        "editor.background": "#010409",
-        "editor.foreground": "#c9d1d9",
-        "editorCursor.foreground": "#58a6ff",
-        "editor.selectionBackground": "#264f78",
-        "editor.selectionHighlightBackground": "#264f7840",
-        "editor.lineHighlightBackground": "#21262d",
-        "editor.findMatchBackground": "#ffd33d44",
-        "editor.findMatchHighlightBackground": "#ffd33d22",
-        "editor.wordHighlightBackground": "#7c3aed40",
-        "editor.wordHighlightStrongBackground": "#7c3aed60",
-        "editor.hoverHighlightBackground": "#58a6ff10",
-        "editorLineNumber.foreground": "#6e7681",
-        "editorLineNumber.activeForeground": "#58a6ff",
-        "editorIndentGuide.background1": "#21262d",
-        "editorIndentGuide.activeBackground1": "#30363d",
-        "editorWhitespace.foreground": "#484f58",
-        "editorRuler.foreground": "#21262d",
-        // Activity Bar
-        "activityBar.background": "#010409",
+        "focusBorder": "#010409",
+        "foreground": "#c9d1d9",
+        "descriptionForeground": "#8b949e",
+        "errorForeground": "#d47616",
+        "textLink.foreground": "#58a6ff",
+        "textLink.activeForeground": "#58a6ff",
+        "textBlockQuote.background": "#010409",
+        "textBlockQuote.border": "#30363d",
+        "textCodeBlock.background": "#6e768166",
+        "textPreformat.foreground": "#8b949e",
+        "textPreformat.background": "#6e768166",
+        "textSeparator.foreground": "#21262d",
+        "icon.foreground": "#8b949e",
+        "keybindingLabel.foreground": "#c9d1d9",
+        "button.background": "#1f6feb",
+        "button.foreground": "#ffffff",
+        "button.hoverBackground": "#388bfd",
+        "button.secondaryBackground": "#282e33",
+        "button.secondaryForeground": "#c9d1d9",
+        "button.secondaryHoverBackground": "#30363d",
+        "checkbox.background": "#161b22",
+        "checkbox.border": "#30363d",
+        "dropdown.background": "#161b22",
+        "dropdown.border": "#30363d",
+        "dropdown.foreground": "#c9d1d9",
+        "dropdown.listBackground": "#161b22",
+        "input.background": "#0d1117",
+        "input.border": "#30363d",
+        "input.foreground": "#c9d1d9",
+        "input.placeholderForeground": "#6e7681",
+        "badge.foreground": "#ffffff",
+        "badge.background": "#1f6feb",
+        "progressBar.background": "#1f6feb",
+        "titleBar.activeForeground": "#8b949e",
+        "titleBar.activeBackground": "#0d1117",
+        "titleBar.inactiveForeground": "#8b949e",
+        "titleBar.inactiveBackground": "#010409",
+        "titleBar.border": "#30363d",
         "activityBar.foreground": "#999999",
-        "activityBar.border": "#21262d",
+        "activityBar.inactiveForeground": "#8b949e",
+        "activityBar.background": "#010409",
+        "activityBarBadge.foreground": "#ffffff",
+        "activityBarBadge.background": "#1f6feb",
         "activityBar.activeBorder": "#f78166",
-        "activityBarBadge.background": "#f78166",
-        "activityBarBadge.foreground": "#010409",
-        // Side Bar
-        "sideBar.background": "#010409",
+        "activityBar.border": "#30363d",
         "sideBar.foreground": "#999999",
-        "sideBar.border": "#21262d",
+        "sideBar.background": "#010409",
+        "sideBar.border": "#30363d",
         "sideBarTitle.foreground": "#c9d1d9",
-        "sideBarSectionHeader.background": "#161b22",
         "sideBarSectionHeader.foreground": "#c9d1d9",
-        // Tabs
-        "tab.activeBackground": "#0d1117",
+        "sideBarSectionHeader.background": "#010409",
+        "sideBarSectionHeader.border": "#30363d",
+        "list.hoverForeground": "#c9d1d9",
+        "list.inactiveSelectionForeground": "#c9d1d9",
+        "list.activeSelectionForeground": "#c9d1d9",
+        "list.hoverBackground": "#6e76811a",
+        "list.inactiveSelectionBackground": "#6e768166",
+        "list.activeSelectionBackground": "#6e768166",
+        "list.focusForeground": "#c9d1d9",
+        "list.focusBackground": "#388bfd26",
+        "list.inactiveFocusBackground": "#388bfd26",
+        "list.highlightForeground": "#58a6ff",
+        "tree.indentGuidesStroke": "#21262d",
+        "notificationCenterHeader.foreground": "#8b949e",
+        "notificationCenterHeader.background": "#161b22",
+        "notifications.foreground": "#c9d1d9",
+        "notifications.background": "#161b22",
+        "notifications.border": "#30363d",
+        "notificationsErrorIcon.foreground": "#d47616",
+        "notificationsWarningIcon.foreground": "#d29922",
+        "notificationsInfoIcon.foreground": "#58a6ff",
+        "pickerGroup.border": "#30363d",
+        "pickerGroup.foreground": "#8b949e",
+        "quickInput.background": "#161b22",
+        "quickInput.foreground": "#c9d1d9",
+        "statusBar.foreground": "#8b949e",
+        "statusBar.background": "#0d1117",
+        "statusBar.border": "#30363d",
+        "statusBar.focusBorder": "#1f6feb80",
+        "statusBar.noFolderBackground": "#0d1117",
+        "statusBar.debuggingForeground": "#ffffff",
+        "statusBar.debuggingBackground": "#b76100",
+        "statusBarItem.prominentBackground": "#6e768166",
+        "statusBarItem.remoteForeground": "#c9d1d9",
+        "statusBarItem.remoteBackground": "#30363d",
+        "statusBarItem.hoverBackground": "#c9d1d914",
+        "statusBarItem.activeBackground": "#c9d1d91f",
+        "statusBarItem.focusBorder": "#1f6feb",
+        "editorGroupHeader.tabsBackground": "#010409",
+        "editorGroupHeader.tabsBorder": "#30363d",
+        "editorGroup.border": "#30363d",
         "tab.activeForeground": "#c9d1d9",
-        "tab.activeBorder": "#0d1117",
-        "tab.activeBorderTop": "#f78166",
-        "tab.inactiveBackground": "#010409",
         "tab.inactiveForeground": "#8b949e",
-        "tab.border": "#21262d",
+        "tab.inactiveBackground": "#010409",
+        "tab.activeBackground": "#0d1117",
         "tab.hoverBackground": "#0d1117",
-        "tab.hoverForeground": "#c9d1d9",
-        "tab.unfocusedActiveBorder": "#0d1117",
-        "tab.unfocusedActiveBorderTop": "#30363d",
         "tab.unfocusedHoverBackground": "#6e76811a",
-        // Editor Groups
-        "editorGroup.border": "#21262d",
-        "editorGroupHeader.noTabsBackground": "#0d1117",
-        "editorGroupHeader.tabsBackground": "#0d1117",
-        "editorGroupHeader.border": "#0d1117",
-        // Status Bar
-        "statusBar.background": "#010409",
-        "statusBar.foreground": "#999999",
-        "statusBar.border": "#21262d",
-        "statusBar.debuggingBackground": "#da3633",
-        "statusBar.debuggingForeground": "#f0f6fc",
-        "statusBar.noFolderBackground": "#010409",
-        // Panel (Terminal, Output, etc.)
+        "tab.border": "#30363d",
+        "tab.unfocusedActiveBorderTop": "#30363d",
+        "tab.activeBorder": "#0d1117",
+        "tab.unfocusedActiveBorder": "#0d1117",
+        "tab.activeBorderTop": "#f78166",
+        "breadcrumb.foreground": "#8b949e",
+        "breadcrumb.focusForeground": "#c9d1d9",
+        "breadcrumb.activeSelectionForeground": "#8b949e",
+        "breadcrumbPicker.background": "#161b22",
+        "editor.foreground": "#c9d1d9",
+        "editor.background": "#010409",
+        "editorWidget.background": "#161b22",
+        "editor.foldBackground": "#6e76811a",
+        "editor.lineHighlightBackground": "#6e76811a",
+        "editorLineNumber.foreground": "#6e7681",
+        "editorLineNumber.activeForeground": "#c9d1d9",
+        "editorIndentGuide.background": "#c9d1d91f",
+        "editorIndentGuide.activeBackground": "#c9d1d93d",
+        "editorWhitespace.foreground": "#484f58",
+        "editorCursor.foreground": "#58a6ff",
+        "editor.findMatchBackground": "#9e6a03",
+        "editor.findMatchHighlightBackground": "#f2cc6080",
+        "editor.linkedEditingBackground": "#58a6ff12",
+        "editor.selectionHighlightBackground": "#58a6ff40",
+        "editor.wordHighlightBackground": "#6e768180",
+        "editor.wordHighlightBorder": "#6e768199",
+        "editor.wordHighlightStrongBackground": "#6e76814d",
+        "editor.wordHighlightStrongBorder": "#6e768199",
+        "editorBracketMatch.background": "#58a6ff40",
+        "editorBracketMatch.border": "#58a6ff99",
+        "editorInlayHint.background": "#8b949e33",
+        "editorInlayHint.foreground": "#8b949e",
+        "editorInlayHint.typeBackground": "#8b949e33",
+        "editorInlayHint.typeForeground": "#8b949e",
+        "editorInlayHint.paramBackground": "#8b949e33",
+        "editorInlayHint.paramForeground": "#8b949e",
+        "editorGutter.modifiedBackground": "#bb800966",
+        "editorGutter.addedBackground": "#388bfd66",
+        "editorGutter.deletedBackground": "#d4761666",
+        "diffEditor.insertedLineBackground": "#1f6feb26",
+        "diffEditor.insertedTextBackground": "#58a6ff4d",
+        "diffEditor.removedLineBackground": "#b7610026",
+        "diffEditor.removedTextBackground": "#ec8e2c4d",
+        "scrollbar.shadow": "#484f5833",
+        "scrollbarSlider.background": "#8b949e33",
+        "scrollbarSlider.hoverBackground": "#8b949e3d",
+        "scrollbarSlider.activeBackground": "#8b949e47",
+        "editorOverviewRuler.border": "#010409",
+        "minimapSlider.background": "#8b949e33",
+        "minimapSlider.hoverBackground": "#8b949e3d",
+        "minimapSlider.activeBackground": "#8b949e47",
         "panel.background": "#010409",
-        "panel.border": "#21262d",
+        "panel.border": "#30363d",
+        "panelTitle.activeBorder": "#f78166",
         "panelTitle.activeForeground": "#c9d1d9",
         "panelTitle.inactiveForeground": "#8b949e",
-        "panelTitle.activeBorder": "#f78166",
-        // Terminal
-        "terminal.background": "#010409",
+        "panelInput.border": "#30363d",
+        "debugIcon.breakpointForeground": "#d47616",
+        "debugConsole.infoForeground": "#8b949e",
+        "debugConsole.warningForeground": "#d29922",
+        "debugConsole.errorForeground": "#fdac54",
+        "debugConsole.sourceForeground": "#e3b341",
+        "debugConsoleInputIcon.foreground": "#bc8cff",
+        "debugTokenExpression.name": "#79c0ff",
+        "debugTokenExpression.value": "#a5d6ff",
+        "debugTokenExpression.string": "#a5d6ff",
+        "debugTokenExpression.boolean": "#79c0ff",
+        "debugTokenExpression.number": "#79c0ff",
+        "debugTokenExpression.error": "#fdac54",
+        "symbolIcon.arrayForeground": "#ec8e2c",
+        "symbolIcon.booleanForeground": "#58a6ff",
+        "symbolIcon.classForeground": "#ec8e2c",
+        "symbolIcon.colorForeground": "#79c0ff",
+        "symbolIcon.constructorForeground": "#d2a8ff",
+        "symbolIcon.enumeratorForeground": "#ec8e2c",
+        "symbolIcon.enumeratorMemberForeground": "#58a6ff",
+        "symbolIcon.eventForeground": "#6e7681",
+        "symbolIcon.fieldForeground": "#ec8e2c",
+        "symbolIcon.fileForeground": "#d29922",
+        "symbolIcon.folderForeground": "#d29922",
+        "symbolIcon.functionForeground": "#bc8cff",
+        "symbolIcon.interfaceForeground": "#ec8e2c",
+        "symbolIcon.keyForeground": "#58a6ff",
+        "symbolIcon.keywordForeground": "#ec8e2c",
+        "symbolIcon.methodForeground": "#bc8cff",
+        "symbolIcon.moduleForeground": "#ec8e2c",
+        "symbolIcon.namespaceForeground": "#ec8e2c",
+        "symbolIcon.nullForeground": "#58a6ff",
+        "symbolIcon.numberForeground": "#58a6ff",
+        "symbolIcon.objectForeground": "#ec8e2c",
+        "symbolIcon.operatorForeground": "#79c0ff",
+        "symbolIcon.packageForeground": "#ec8e2c",
+        "symbolIcon.propertyForeground": "#ec8e2c",
+        "symbolIcon.referenceForeground": "#58a6ff",
+        "symbolIcon.snippetForeground": "#58a6ff",
+        "symbolIcon.stringForeground": "#79c0ff",
+        "symbolIcon.structForeground": "#ec8e2c",
+        "symbolIcon.textForeground": "#79c0ff",
+        "symbolIcon.typeParameterForeground": "#79c0ff",
+        "symbolIcon.unitForeground": "#58a6ff",
+        "symbolIcon.variableForeground": "#ec8e2c",
+        "symbolIcon.constantForeground": [
+            "#cae8ff",
+            "#a5d6ff",
+            "#79c0ff",
+            "#58a6ff",
+            "#388bfd",
+            "#1f6feb",
+            "#1158c7",
+            "#0d419d",
+            "#0c2d6b",
+            "#051d4d"
+        ],
         "terminal.foreground": "#c9d1d9",
         "terminal.ansiBlack": "#484f58",
-        "terminal.ansiRed": "#ff7b72",
-        "terminal.ansiGreen": "#7ee787",
-        "terminal.ansiYellow": "#ffd33d",
+        "terminal.ansiRed": "#ec8e2c",
+        "terminal.ansiGreen": "#58a6ff",
+        "terminal.ansiYellow": "#d29922",
         "terminal.ansiBlue": "#58a6ff",
         "terminal.ansiMagenta": "#bc8cff",
         "terminal.ansiCyan": "#39c5cf",
         "terminal.ansiWhite": "#b1bac4",
         "terminal.ansiBrightBlack": "#6e7681",
-        "terminal.ansiBrightRed": "#ffa198",
-        "terminal.ansiBrightGreen": "#56d364",
+        "terminal.ansiBrightRed": "#fdac54",
+        "terminal.ansiBrightGreen": "#79c0ff",
         "terminal.ansiBrightYellow": "#e3b341",
         "terminal.ansiBrightBlue": "#79c0ff",
         "terminal.ansiBrightMagenta": "#d2a8ff",
         "terminal.ansiBrightCyan": "#56d4dd",
-        "terminal.ansiBrightWhite": "#f0f6fc",
-        // Focus Border
-        "focusBorder": "#010409",
-        // Input
-        "input.background": "#21262d",
-        "input.foreground": "#c9d1d9",
-        "input.border": "#30363d",
-        "input.placeholderForeground": "#8b949e",
-        "inputOption.activeBorder": "#f78166",
-        "inputValidation.errorBackground": "#da3633",
-        "inputValidation.errorBorder": "#f85149",
-        "inputValidation.warningBackground": "#bb8009",
-        "inputValidation.warningBorder": "#ffd33d",
-        // Dropdown
-        "dropdown.background": "#21262d",
-        "dropdown.foreground": "#c9d1d9",
-        "dropdown.border": "#30363d",
-        // List/Tree
-        "list.activeSelectionBackground": "#21262d",
-        "list.activeSelectionForeground": "#c9d1d9",
-        "list.inactiveSelectionBackground": "#161b22",
-        "list.inactiveSelectionForeground": "#c9d1d9",
-        "list.hoverBackground": "#161b22",
-        "list.hoverForeground": "#c9d1d9",
-        "list.focusBackground": "#21262d",
-        "list.focusForeground": "#c9d1d9",
-        // Button
-        "button.background": "#238636",
-        "button.foreground": "#f0f6fc",
-        "button.hoverBackground": "#2ea043",
-        "button.secondaryBackground": "#21262d",
-        "button.secondaryForeground": "#c9d1d9",
-        "button.secondaryHoverBackground": "#30363d",
-        // Badge
-        "badge.background": "#1f6feb",
-        "badge.foreground": "#f0f6fc",
-        // Progress Bar
-        "progressBar.background": "#1f6feb",
-        // Scrollbar
-        "scrollbar.shadow": "#010409",
-        "scrollbarSlider.background": "#6e768140",
-        "scrollbarSlider.hoverBackground": "#6e768160",
-        "scrollbarSlider.activeBackground": "#6e768180",
-        // Widget
-        "widget.shadow": "#010409",
-        "widget.border": "#30363d",
-        // Toolbar
-        "toolbar.hoverBackground": "#21262d",
-        // Menu
-        "menu.background": "#161b22",
-        "menu.foreground": "#c9d1d9",
-        "menu.selectionBackground": "#21262d",
-        "menu.selectionForeground": "#c9d1d9",
-        "menu.separatorBackground": "#30363d",
-        "menubar.selectionBackground": "#21262d",
-        "menubar.selectionForeground": "#c9d1d9",
-        // Notifications
-        "notificationCenter.border": "#30363d",
-        "notificationCenterHeader.background": "#161b22",
-        "notificationCenterHeader.foreground": "#c9d1d9",
-        "notificationToast.border": "#30363d",
-        "notifications.background": "#161b22",
-        "notifications.foreground": "#c9d1d9",
-        "notifications.border": "#30363d",
-        "notificationLink.foreground": "#58a6ff",
-        // Extensions
-        "extensionButton.prominentBackground": "#238636",
-        "extensionButton.prominentForeground": "#f0f6fc",
-        "extensionButton.prominentHoverBackground": "#2ea043",
-        // Peek View
-        "peekView.border": "#30363d",
-        "peekViewEditor.background": "#161b22",
-        "peekViewEditor.matchHighlightBackground": "#ffd33d44",
-        "peekViewResult.background": "#161b22",
-        "peekViewResult.fileForeground": "#c9d1d9",
-        "peekViewResult.lineForeground": "#8b949e",
-        "peekViewResult.matchHighlightBackground": "#ffd33d44",
-        "peekViewResult.selectionBackground": "#21262d",
-        "peekViewResult.selectionForeground": "#c9d1d9",
-        "peekViewTitle.background": "#161b22",
-        "peekViewTitleDescription.foreground": "#8b949e",
-        "peekViewTitleLabel.foreground": "#c9d1d9",
-        // Merge Conflicts
-        "merge.currentHeaderBackground": "#2ea04340",
-        "merge.currentContentBackground": "#2ea04320",
-        "merge.incomingHeaderBackground": "#1f6feb40",
-        "merge.incomingContentBackground": "#1f6feb20",
-        "merge.border": "#30363d",
-        "merge.commonContentBackground": "#6e768120",
-        "merge.commonHeaderBackground": "#6e768140",
-        "editorOverviewRuler.currentContentForeground": "#2ea043",
-        "editorOverviewRuler.incomingContentForeground": "#1f6feb",
-        "editorOverviewRuler.commonContentForeground": "#6e7681",
-        // Git Colors
-        "gitDecoration.addedResourceForeground": "#7ee787",
-        "gitDecoration.modifiedResourceForeground": "#ffd33d",
-        "gitDecoration.deletedResourceForeground": "#ff7b72",
-        "gitDecoration.untrackedResourceForeground": "#7ee787",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "editorBracketHighlight.foreground1": "#79c0ff",
+        "editorBracketHighlight.foreground2": "#79c0ff",
+        "editorBracketHighlight.foreground3": "#e3b341",
+        "editorBracketHighlight.foreground4": "#fdac54",
+        "editorBracketHighlight.foreground5": "#ff9bce",
+        "editorBracketHighlight.foreground6": "#d2a8ff",
+        "editorBracketHighlight.unexpectedBracket.foreground": "#8b949e",
+        "gitDecoration.addedResourceForeground": "#58a6ff",
+        "gitDecoration.modifiedResourceForeground": "#d29922",
+        "gitDecoration.deletedResourceForeground": "#d47616",
+        "gitDecoration.untrackedResourceForeground": "#58a6ff",
         "gitDecoration.ignoredResourceForeground": "#6e7681",
-        "gitDecoration.conflictingResourceForeground": "#ff9500",
+        "gitDecoration.conflictingResourceForeground": "#d47616",
         "gitDecoration.submoduleResourceForeground": "#8b949e",
-        // Error Lens (from user's customizations)
-        "errorLens.errorBackground": "#aa0000",
-        "errorLens.errorBackgroundLight": "#aa0000",
-        "errorLens.errorForeground": "#ffffff",
-        "errorLens.errorForegroundLight": "#ffffff",
-        "errorLens.hintBackground": "#f6d258",
-        "errorLens.hintBackgroundLight": "#f6d258",
-        "errorLens.hintForeground": "#ffffff",
-        "errorLens.hintForegroundLight": "#ffffff",
-        "errorLens.infoBackground": "#88a2bc",
-        "errorLens.infoBackgroundLight": "#88a2bc",
-        "errorLens.infoForeground": "#ffffff",
-        "errorLens.infoForegroundLight": "#ffffff",
-        "errorLens.warningBackground": "#ff8800",
-        "errorLens.warningBackgroundLight": "#ff8800",
-        "errorLens.warningForeground": "#ffffff",
-        "errorLens.warningForegroundLight": "#ffffff"
+        "debugToolBar.background": "#161b22",
+        "editor.stackFrameHighlightBackground": "#bb800966",
+        "editor.focusedStackFrameHighlightBackground": "#388bfd66",
+        "peekViewEditor.matchHighlightBackground": "#bb800966",
+        "peekViewResult.matchHighlightBackground": "#bb800966",
+        "peekViewEditor.background": "#6e76811a",
+        "peekViewResult.background": "#0d1117",
+        "settings.headerForeground": "#c9d1d9",
+        "settings.modifiedItemIndicator": "#bb800966",
+        "welcomePage.buttonBackground": "#21262d",
+        "welcomePage.buttonHoverBackground": "#30363d"
     },
     "tokenColors": [
         {
-            "name": "Comment",
             "scope": [
                 "comment",
-                "punctuation.definition.comment"
+                "punctuation.definition.comment",
+                "string.comment"
             ],
             "settings": {
-                "fontStyle": "italic",
-                "foreground": "#6e7681"
+                "foreground": "#8b949e"
             }
         },
         {
-            "name": "Variables",
             "scope": [
-                "variable",
-                "string constant.other.placeholder"
+                "constant.other.placeholder",
+                "constant.character"
             ],
             "settings": {
-                "foreground": "#c9d1d9"
+                "foreground": "#ec8e2c"
             }
         },
         {
-            "name": "Colors",
             "scope": [
-                "constant.other.color"
+                "constant",
+                "entity.name.constant",
+                "variable.other.constant",
+                "variable.other.enummember",
+                "variable.language",
+                "entity"
             ],
             "settings": {
                 "foreground": "#79c0ff"
             }
         },
         {
-            "name": "Invalid",
             "scope": [
-                "invalid",
-                "invalid.illegal"
+                "entity.name",
+                "meta.export.default",
+                "meta.definition.variable"
             ],
             "settings": {
-                "foreground": "#f85149"
+                "foreground": "#fdac54"
             }
         },
         {
-            "name": "Keyword, Storage",
             "scope": [
-                "keyword",
-                "storage.type",
-                "storage.modifier"
-            ],
-            "settings": {
-                "foreground": "#ff7b72"
-            }
-        },
-        {
-            "name": "Operator, Misc",
-            "scope": [
-                "keyword.control",
-                "constant.other.color",
-                "punctuation",
-                "meta.tag",
-                "punctuation.definition.tag",
-                "punctuation.separator.inheritance.php",
-                "punctuation.definition.tag.html",
-                "punctuation.definition.tag.begin.html",
-                "punctuation.definition.tag.end.html",
-                "punctuation.section.embedded",
-                "keyword.other.template",
-                "keyword.other.substitution"
+                "variable.parameter.function",
+                "meta.jsx.children",
+                "meta.block",
+                "meta.tag.attributes",
+                "entity.name.constant",
+                "meta.object.member",
+                "meta.embedded.expression"
             ],
             "settings": {
                 "foreground": "#c9d1d9"
             }
         },
         {
-            "name": "Tag",
-            "scope": [
-                "entity.name.tag",
-                "meta.tag.sgml",
-                "markup.deleted.git_gutter"
-            ],
-            "settings": {
-                "foreground": "#7ee787"
-            }
-        },
-        {
-            "name": "Function, Special Method",
-            "scope": [
-                "entity.name.function",
-                "meta.function-call",
-                "variable.function",
-                "support.function",
-                "keyword.other.special-method"
-            ],
+            "scope": "entity.name.function",
             "settings": {
                 "foreground": "#d2a8ff"
             }
         },
         {
-            "name": "Block Level Variables",
             "scope": [
-                "meta.block variable.other"
-            ],
-            "settings": {
-                "foreground": "#ffa657"
-            }
-        },
-        {
-            "name": "Other Variable, String Link",
-            "scope": [
-                "support.other.variable",
-                "string.other.link"
-            ],
-            "settings": {
-                "foreground": "#ffa657"
-            }
-        },
-        {
-            "name": "Number, Constant, Function Argument, Tag Attribute, Embedded",
-            "scope": [
-                "constant.numeric",
-                "constant.language",
-                "support.constant",
-                "constant.character",
-                "constant.escape",
-                "variable.parameter",
-                "keyword.other.unit",
-                "keyword.other"
-            ],
-            "settings": {
-                "foreground": "#79c0ff"
-            }
-        },
-        {
-            "name": "String, Symbols, Inherited Class, Markup Heading",
-            "scope": [
-                "string",
-                "constant.other.symbol",
-                "constant.other.key",
-                "entity.other.inherited-class",
-                "markup.heading",
-                "markup.inserted.git_gutter",
-                "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js"
+                "entity.name.tag",
+                "support.class.component"
             ],
             "settings": {
                 "foreground": "#a5d6ff"
             }
         },
         {
-            "name": "Class, Support",
-            "scope": [
-                "entity.name",
-                "support.type",
-                "support.class",
-                "support.other.namespace.use.php",
-                "meta.use.php",
-                "support.other.namespace.php",
-                "markup.changed.git_gutter",
-                "support.type.sys-types"
-            ],
+            "scope": "keyword",
             "settings": {
-                "foreground": "#ffa657"
+                "foreground": "#ec8e2c"
             }
         },
         {
-            "name": "Entity Types",
             "scope": [
-                "support.type"
+                "storage",
+                "storage.type"
             ],
             "settings": {
-                "foreground": "#58a6ff"
+                "foreground": "#ec8e2c"
             }
         },
         {
-            "name": "CSS Class and Support",
             "scope": [
-                "source.css support.type.property-name",
-                "source.sass support.type.property-name",
-                "source.scss support.type.property-name",
-                "source.less support.type.property-name",
-                "source.stylus support.type.property-name",
-                "source.postcss support.type.property-name"
+                "storage.modifier.package",
+                "storage.modifier.import",
+                "storage.type.java"
             ],
             "settings": {
-                "foreground": "#58a6ff"
+                "foreground": "#c9d1d9"
             }
         },
         {
-            "name": "Sub-methods",
             "scope": [
-                "entity.name.module.js",
-                "variable.import.parameter.js",
-                "variable.other.class.js"
+                "string",
+                "string punctuation.section.embedded source"
             ],
             "settings": {
-                "foreground": "#ff7b72"
+                "foreground": "#a5d6ff"
             }
         },
         {
-            "name": "Language methods",
-            "scope": [
-                "variable.language"
-            ],
-            "settings": {
-                "fontStyle": "italic",
-                "foreground": "#ff7b72"
-            }
-        },
-        {
-            "name": "entity.name.method.js",
-            "scope": [
-                "entity.name.method.js"
-            ],
-            "settings": {
-                "fontStyle": "italic",
-                "foreground": "#d2a8ff"
-            }
-        },
-        {
-            "name": "meta.method.js",
-            "scope": [
-                "meta.class-method.js entity.name.function.js",
-                "variable.function.constructor"
-            ],
-            "settings": {
-                "foreground": "#d2a8ff"
-            }
-        },
-        {
-            "name": "Attributes",
-            "scope": [
-                "entity.other.attribute-name"
-            ],
+            "scope": "support",
             "settings": {
                 "foreground": "#79c0ff"
             }
         },
         {
-            "name": "HTML Attributes",
-            "scope": [
-                "text.html.basic entity.other.attribute-name.html",
-                "text.html.basic entity.other.attribute-name"
-            ],
+            "scope": "meta.property-name",
+            "settings": {
+                "foreground": "#79c0ff"
+            }
+        },
+        {
+            "scope": "variable",
+            "settings": {
+                "foreground": "#fdac54"
+            }
+        },
+        {
+            "scope": "variable.other",
+            "settings": {
+                "foreground": "#c9d1d9"
+            }
+        },
+        {
+            "scope": "invalid.broken",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#ffa657"
+                "foreground": "#fdac54"
             }
         },
         {
-            "name": "CSS Classes",
-            "scope": [
-                "entity.other.attribute-name.class"
-            ],
+            "scope": "invalid.deprecated",
             "settings": {
-                "foreground": "#ffa657"
+                "fontStyle": "italic",
+                "foreground": "#fdac54"
             }
         },
         {
-            "name": "CSS ID's",
-            "scope": [
-                "source.sass keyword.control"
-            ],
+            "scope": "invalid.illegal",
             "settings": {
-                "foreground": "#d2a8ff"
+                "fontStyle": "italic",
+                "foreground": "#fdac54"
             }
         },
         {
-            "name": "Inserted",
-            "scope": [
-                "markup.inserted"
-            ],
+            "scope": "invalid.unimplemented",
             "settings": {
-                "foreground": "#7ee787"
+                "fontStyle": "italic",
+                "foreground": "#fdac54"
             }
         },
         {
-            "name": "Deleted",
-            "scope": [
-                "markup.deleted"
-            ],
+            "scope": "carriage-return",
             "settings": {
-                "foreground": "#ff7b72"
+                "fontStyle": "italic underline",
+                "background": "#ec8e2c",
+                "foreground": "#f0f6fc",
+                "content": "^M"
             }
         },
         {
-            "name": "Changed",
-            "scope": [
-                "markup.changed"
-            ],
+            "scope": "message.error",
             "settings": {
-                "foreground": "#ffa657"
+                "foreground": "#fdac54"
             }
         },
         {
-            "name": "Regular Expressions",
+            "scope": "string variable",
+            "settings": {
+                "foreground": "#79c0ff"
+            }
+        },
+        {
             "scope": [
+                "source.regexp",
                 "string.regexp"
             ],
             "settings": {
@@ -504,321 +445,207 @@
             }
         },
         {
-            "name": "Escape Characters",
             "scope": [
-                "constant.character.escape"
+                "string.regexp.character-class",
+                "string.regexp constant.character.escape",
+                "string.regexp source.ruby.embedded",
+                "string.regexp string.regexp.arbitrary-repitition"
             ],
             "settings": {
-                "foreground": "#39c5cf"
+                "foreground": "#a5d6ff"
             }
         },
         {
-            "name": "URL",
+            "scope": "string.regexp constant.character.escape",
+            "settings": {
+                "fontStyle": "bold",
+                "foreground": "#a5d6ff"
+            }
+        },
+        {
+            "scope": "support.constant",
+            "settings": {
+                "foreground": "#79c0ff"
+            }
+        },
+        {
+            "scope": "support.variable",
+            "settings": {
+                "foreground": "#79c0ff"
+            }
+        },
+        {
+            "scope": "support.type.property-name.json",
+            "settings": {
+                "foreground": "#a5d6ff"
+            }
+        },
+        {
+            "scope": "meta.module-reference",
+            "settings": {
+                "foreground": "#79c0ff"
+            }
+        },
+        {
+            "scope": "punctuation.definition.list.begin.markdown",
+            "settings": {
+                "foreground": "#fdac54"
+            }
+        },
+        {
             "scope": [
-                "*url*",
-                "*link*",
-                "*uri*"
+                "markup.heading",
+                "markup.heading entity.name"
+            ],
+            "settings": {
+                "fontStyle": "bold",
+                "foreground": "#79c0ff"
+            }
+        },
+        {
+            "scope": "markup.quote",
+            "settings": {
+                "foreground": "#a5d6ff"
+            }
+        },
+        {
+            "scope": "markup.italic",
+            "settings": {
+                "fontStyle": "italic",
+                "foreground": "#c9d1d9"
+            }
+        },
+        {
+            "scope": "markup.bold",
+            "settings": {
+                "fontStyle": "bold",
+                "foreground": "#c9d1d9"
+            }
+        },
+        {
+            "scope": [
+                "markup.underline"
             ],
             "settings": {
                 "fontStyle": "underline"
             }
         },
         {
-            "name": "Decorators",
             "scope": [
-                "tag.decorator.js entity.name.tag.js",
-                "tag.decorator.js punctuation.definition.tag.js"
+                "markup.strikethrough"
             ],
             "settings": {
-                "fontStyle": "italic",
-                "foreground": "#d2a8ff"
+                "fontStyle": "strikethrough"
             }
         },
         {
-            "name": "ES7 Bind Operator",
-            "scope": [
-                "source.js constant.other.object.key.js string.unquoted.label.js"
-            ],
-            "settings": {
-                "fontStyle": "italic",
-                "foreground": "#ff7b72"
-            }
-        },
-        {
-            "name": "JSON Key - Level 0",
-            "scope": [
-                "source.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
+            "scope": "markup.inline.raw",
             "settings": {
                 "foreground": "#79c0ff"
             }
         },
         {
-            "name": "JSON Key - Level 1",
             "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+                "markup.deleted",
+                "meta.diff.header.from-file",
+                "punctuation.definition.deleted"
             ],
             "settings": {
-                "foreground": "#ffa657"
+                "background": "#331c04",
+                "foreground": "#fdac54"
             }
         },
         {
-            "name": "JSON Key - Level 2",
             "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+                "punctuation.section.embedded"
             ],
             "settings": {
-                "foreground": "#ff9500"
+                "foreground": "#ec8e2c"
             }
         },
         {
-            "name": "JSON Key - Level 3",
             "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+                "markup.inserted",
+                "meta.diff.header.to-file",
+                "punctuation.definition.inserted"
             ],
             "settings": {
-                "foreground": "#ff7b72"
+                "background": "#051d4d",
+                "foreground": "#a5d6ff"
             }
         },
         {
-            "name": "JSON Key - Level 4",
             "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+                "markup.changed",
+                "punctuation.definition.changed"
             ],
             "settings": {
-                "foreground": "#bc8cff"
+                "background": "#4e2906",
+                "foreground": "#fdac54"
             }
         },
         {
-            "name": "JSON Key - Level 5",
             "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+                "markup.ignored",
+                "markup.untracked"
             ],
             "settings": {
-                "foreground": "#58a6ff"
+                "foreground": "#161b22",
+                "background": "#79c0ff"
             }
         },
         {
-            "name": "JSON Key - Level 6",
-            "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
+            "scope": "meta.diff.range",
             "settings": {
-                "foreground": "#ffa657"
+                "foreground": "#d2a8ff",
+                "fontStyle": "bold"
             }
         },
         {
-            "name": "JSON Key - Level 7",
-            "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
-            "settings": {
-                "foreground": "#ff9500"
-            }
-        },
-        {
-            "name": "JSON Key - Level 8",
-            "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
-            "settings": {
-                "foreground": "#7ee787"
-            }
-        },
-        {
-            "name": "Markdown - Plain",
-            "scope": [
-                "text.html.markdown",
-                "punctuation.definition.list_item.markdown"
-            ],
-            "settings": {
-                "foreground": "#c9d1d9"
-            }
-        },
-        {
-            "name": "Markdown - Markup Raw Inline",
-            "scope": [
-                "text.html.markdown markup.inline.raw.markdown"
-            ],
+            "scope": "meta.diff.header",
             "settings": {
                 "foreground": "#79c0ff"
             }
         },
         {
-            "name": "Markdown - Markup Raw Inline Punctuation",
-            "scope": [
-                "text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown"
-            ],
-            "settings": {
-                "foreground": "#6e7681"
-            }
-        },
-        {
-            "name": "Markdown - Heading",
-            "scope": [
-                "markdown.heading",
-                "markup.heading | markup.heading entity.name",
-                "markup.heading.markdown punctuation.definition.heading.markdown"
-            ],
-            "settings": {
-                "foreground": "#58a6ff"
-            }
-        },
-        {
-            "name": "Markup - Italic",
-            "scope": [
-                "markup.italic"
-            ],
-            "settings": {
-                "fontStyle": "italic",
-                "foreground": "#ffa657"
-            }
-        },
-        {
-            "name": "Markup - Bold",
-            "scope": [
-                "markup.bold",
-                "markup.bold string"
-            ],
+            "scope": "meta.separator",
             "settings": {
                 "fontStyle": "bold",
-                "foreground": "#ffa657"
+                "foreground": "#79c0ff"
             }
         },
         {
-            "name": "Markup - Bold-Italic",
-            "scope": [
-                "markup.bold markup.italic",
-                "markup.italic markup.bold",
-                "markup.quote markup.bold",
-                "markup.bold markup.italic string",
-                "markup.italic markup.bold string",
-                "markup.quote markup.bold string"
-            ],
-            "settings": {
-                "fontStyle": "bold",
-                "foreground": "#ffa657"
-            }
-        },
-        {
-            "name": "Markup - Underline",
-            "scope": [
-                "markup.underline"
-            ],
-            "settings": {
-                "fontStyle": "underline",
-                "foreground": "#ff9500"
-            }
-        },
-        {
-            "name": "Markdown - Blockquote",
-            "scope": [
-                "markup.quote punctuation.definition.blockquote.markdown"
-            ],
-            "settings": {
-                "foreground": "#6e7681"
-            }
-        },
-        {
-            "name": "Markup - Quote",
-            "scope": [
-                "markup.quote"
-            ],
-            "settings": {
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "Markdown - Link",
-            "scope": [
-                "string.other.link.title.markdown"
-            ],
-            "settings": {
-                "foreground": "#58a6ff"
-            }
-        },
-        {
-            "name": "Markdown - Link Description",
-            "scope": [
-                "string.other.link.description.title.markdown"
-            ],
+            "scope": "meta.output",
             "settings": {
                 "foreground": "#79c0ff"
             }
         },
         {
-            "name": "Markdown - Link Anchor",
             "scope": [
-                "constant.other.reference.link.markdown"
+                "brackethighlighter.tag",
+                "brackethighlighter.curly",
+                "brackethighlighter.round",
+                "brackethighlighter.square",
+                "brackethighlighter.angle",
+                "brackethighlighter.quote"
             ],
             "settings": {
-                "foreground": "#ffa657"
+                "foreground": "#8b949e"
             }
         },
         {
-            "name": "Markup - Raw Block",
-            "scope": [
-                "markup.raw.block"
-            ],
+            "scope": "brackethighlighter.unmatched",
             "settings": {
-                "foreground": "#79c0ff"
+                "foreground": "#fdac54"
             }
         },
         {
-            "name": "Markdown - Raw Block Fenced",
             "scope": [
-                "markup.raw.block.fenced.markdown"
+                "constant.other.reference.link",
+                "string.other.link"
             ],
             "settings": {
-                "foreground": "#c9d1d900"
-            }
-        },
-        {
-            "name": "Markdown - Fenced Bode Block",
-            "scope": [
-                "punctuation.definition.fenced.markdown"
-            ],
-            "settings": {
-                "foreground": "#c9d1d900"
-            }
-        },
-        {
-            "name": "Markdown - Fenced Bode Block Variable",
-            "scope": [
-                "markup.raw.block.fenced.markdown",
-                "variable.language.fenced.markdown",
-                "punctuation.section.class.end"
-            ],
-            "settings": {
-                "foreground": "#c9d1d9"
-            }
-        },
-        {
-            "name": "Markdown - Fenced Language",
-            "scope": [
-                "variable.language.fenced.markdown"
-            ],
-            "settings": {
-                "foreground": "#6e7681"
-            }
-        },
-        {
-            "name": "Markdown - Separator",
-            "scope": [
-                "meta.separator"
-            ],
-            "settings": {
-                "fontStyle": "bold",
-                "foreground": "#6e7681"
-            }
-        },
-        {
-            "name": "Markup - Table",
-            "scope": [
-                "markup.table"
-            ],
-            "settings": {
-                "foreground": "#c9d1d9"
+                "foreground": "#a5d6ff"
             }
         }
     ]

--- a/themes/super-blue-color-theme.json
+++ b/themes/super-blue-color-theme.json
@@ -3,244 +3,245 @@
     "type": "dark",
     "semanticHighlighting": true,
     "colors": {
-        "focusBorder": "#010409",
-        "foreground": "#c9d1d9",
-        "descriptionForeground": "#8b949e",
-        "errorForeground": "#d47616",
-        "textLink.foreground": "#58a6ff",
-        "textLink.activeForeground": "#58a6ff",
-        "textBlockQuote.background": "#010409",
-        "textBlockQuote.border": "#30363d",
-        "textCodeBlock.background": "#6e768166",
-        "textPreformat.foreground": "#8b949e",
-        "textPreformat.background": "#6e768166",
-        "textSeparator.foreground": "#21262d",
-        "icon.foreground": "#8b949e",
-        "keybindingLabel.foreground": "#c9d1d9",
-        "button.background": "#1f6feb",
+        "focusBorder": "#ffffff",
+        "foreground": "#24292f",
+        "descriptionForeground": "#57606a",
+        "errorForeground": "#b35900",
+        "textLink.foreground": "#0969da",
+        "textLink.activeForeground": "#0969da",
+        "textBlockQuote.background": "#f6f8fa",
+        "textBlockQuote.border": "#d0d7de",
+        "textCodeBlock.background": "#afb8c133",
+        "textPreformat.foreground": "#57606a",
+        "textPreformat.background": "#afb8c133",
+        "textSeparator.foreground": "#d8dee4",
+        "icon.foreground": "#57606a",
+        "keybindingLabel.foreground": "#24292f",
+        "button.background": "#218bff",
         "button.foreground": "#ffffff",
-        "button.hoverBackground": "#388bfd",
-        "button.secondaryBackground": "#282e33",
-        "button.secondaryForeground": "#c9d1d9",
-        "button.secondaryHoverBackground": "#30363d",
-        "checkbox.background": "#161b22",
-        "checkbox.border": "#30363d",
-        "dropdown.background": "#161b22",
-        "dropdown.border": "#30363d",
-        "dropdown.foreground": "#c9d1d9",
-        "dropdown.listBackground": "#161b22",
-        "input.background": "#0d1117",
-        "input.border": "#30363d",
-        "input.foreground": "#c9d1d9",
-        "input.placeholderForeground": "#6e7681",
+        "button.hoverBackground": "#0969da",
+        "button.secondaryBackground": "#ebecf0",
+        "button.secondaryForeground": "#24292f",
+        "button.secondaryHoverBackground": "#f3f4f6",
+        "checkbox.background": "#f6f8fa",
+        "checkbox.border": "#d0d7de",
+        "dropdown.background": "#ffffff",
+        "dropdown.border": "#d0d7de",
+        "dropdown.foreground": "#24292f",
+        "dropdown.listBackground": "#ffffff",
+        "input.background": "#ffffff",
+        "input.border": "#d0d7de",
+        "input.foreground": "#24292f",
+        "input.placeholderForeground": "#6e7781",
         "badge.foreground": "#ffffff",
-        "badge.background": "#1f6feb",
-        "progressBar.background": "#1f6feb",
-        "titleBar.activeForeground": "#000000",
-        "titleBar.activeBackground": "#00ccff",
-        "titleBar.inactiveForeground": "#8b949e",
-        "titleBar.inactiveBackground": "#010409",
-        "titleBar.border": "#30363d",
-        "activityBar.foreground": "#c9d1d9",
-        "activityBar.inactiveForeground": "#8b949e",
-        "activityBar.background": "#0d1117",
+        "badge.background": "#0969da",
+        "progressBar.background": "#0969da",
+        "titleBar.activeForeground": "#57606a",
+        "titleBar.activeBackground": "#ffffff",
+        "titleBar.inactiveForeground": "#57606a",
+        "titleBar.inactiveBackground": "#f6f8fa",
+        "titleBar.border": "#d0d7de",
+        "activityBar.foreground": "#24292f",
+        "activityBar.inactiveForeground": "#57606a",
+        "activityBar.background": "#ffffff",
         "activityBarBadge.foreground": "#ffffff",
-        "activityBarBadge.background": "#1f6feb",
-        "activityBar.activeBorder": "#f78166",
-        "activityBar.border": "#30363d",
-        "sideBar.foreground": "#c9d1d9",
-        "sideBar.background": "#00205A",
-        "sideBar.border": "#555555",
-        "sideBarTitle.foreground": "#c9d1d9",
+        "activityBarBadge.background": "#0969da",
+        "activityBar.activeBorder": "#fd8c73",
+        "activityBar.border": "#d0d7de",
+        "sideBar.foreground": "#777777",
+        "sideBar.background": "#ffffff",
+        "sideBar.border": "#777777",
         "sideBarTitle.background": "#000000",
-        "sideBarSectionHeader.foreground": "#c9d1d9",
-        "sideBarSectionHeader.background": "#010409",
-        "sideBarSectionHeader.border": "#30363d",
-        "list.hoverForeground": "#c9d1d9",
-        "list.inactiveSelectionForeground": "#c9d1d9",
-        "list.activeSelectionForeground": "#c9d1d9",
-        "list.hoverBackground": "#6e76811a",
-        "list.inactiveSelectionBackground": "#6e768166",
-        "list.activeSelectionBackground": "#6e768166",
-        "list.focusForeground": "#c9d1d9",
-        "list.focusBackground": "#388bfd26",
-        "list.inactiveFocusBackground": "#388bfd26",
-        "list.highlightForeground": "#58a6ff",
-        "tree.indentGuidesStroke": "#21262d",
-        "notificationCenterHeader.foreground": "#8b949e",
-        "notificationCenterHeader.background": "#161b22",
-        "notifications.foreground": "#c9d1d9",
-        "notifications.background": "#161b22",
-        "notifications.border": "#30363d",
-        "notificationsErrorIcon.foreground": "#d47616",
-        "notificationsWarningIcon.foreground": "#d29922",
-        "notificationsInfoIcon.foreground": "#58a6ff",
-        "pickerGroup.border": "#30363d",
-        "pickerGroup.foreground": "#8b949e",
-        "quickInput.background": "#161b22",
-        "quickInput.foreground": "#c9d1d9",
-        "statusBar.foreground": "#8b949e",
-        "statusBar.background": "#0d1117",
-        "statusBar.border": "#30363d",
-        "statusBar.focusBorder": "#1f6feb80",
-        "statusBar.noFolderBackground": "#0d1117",
+        "sideBarTitle.foreground": "#c9d1d9",
+        "sideBarSectionHeader.foreground": "#24292f",
+        "sideBarSectionHeader.background": "#f6f8fa",
+        "sideBarSectionHeader.border": "#d0d7de",
+        "list.hoverForeground": "#24292f",
+        "list.inactiveSelectionForeground": "#24292f",
+        "list.activeSelectionForeground": "#24292f",
+        "list.hoverBackground": "#eaeef280",
+        "list.inactiveSelectionBackground": "#afb8c133",
+        "list.activeSelectionBackground": "#afb8c133",
+        "list.focusForeground": "#24292f",
+        "list.focusBackground": "#ddf4ff",
+        "list.inactiveFocusBackground": "#ddf4ff",
+        "list.highlightForeground": "#0969da",
+        "tree.indentGuidesStroke": "#d8dee4",
+        "notificationCenterHeader.foreground": "#57606a",
+        "notificationCenterHeader.background": "#f6f8fa",
+        "notifications.foreground": "#24292f",
+        "notifications.background": "#ffffff",
+        "notifications.border": "#d0d7de",
+        "notificationsErrorIcon.foreground": "#b35900",
+        "notificationsWarningIcon.foreground": "#9a6700",
+        "notificationsInfoIcon.foreground": "#0969da",
+        "pickerGroup.border": "#d0d7de",
+        "pickerGroup.foreground": "#57606a",
+        "quickInput.background": "#ffffff",
+        "quickInput.foreground": "#24292f",
+        "statusBar.foreground": "#57606a",
+        "statusBar.background": "#ffffff",
+        "statusBar.border": "#d0d7de",
+        "statusBar.focusBorder": "#0969da80",
+        "statusBar.noFolderBackground": "#ffffff",
         "statusBar.debuggingForeground": "#ffffff",
-        "statusBar.debuggingBackground": "#b76100",
-        "statusBarItem.prominentBackground": "#6e768166",
-        "statusBarItem.remoteForeground": "#c9d1d9",
-        "statusBarItem.remoteBackground": "#30363d",
-        "statusBarItem.hoverBackground": "#c9d1d914",
-        "statusBarItem.activeBackground": "#c9d1d91f",
-        "statusBarItem.focusBorder": "#1f6feb",
-        "editorGroupHeader.tabsBackground": "#010409",
-        "editorGroupHeader.tabsBorder": "#30363d",
-        "editorGroup.border": "#30363d",
+        "statusBar.debuggingBackground": "#b35900",
+        "statusBarItem.prominentBackground": "#afb8c133",
+        "statusBarItem.remoteForeground": "#24292f",
+        "statusBarItem.remoteBackground": "#eaeef2",
+        "statusBarItem.hoverBackground": "#24292f14",
+        "statusBarItem.activeBackground": "#24292f1f",
+        "statusBarItem.focusBorder": "#0969da",
+        "editorGroupHeader.border": "#0d1117",
+        "editorGroupHeader.noTabsBackground": "#0d1117",
+        "editorGroupHeader.tabsBackground": "#0d1117",
+        "editorGroup.border": "#d0d7de",
         "tab.activeForeground": "#c9d1d9",
         "tab.inactiveForeground": "#8b949e",
         "tab.inactiveBackground": "#010409",
         "tab.activeBackground": "#0d1117",
         "tab.hoverBackground": "#0d1117",
         "tab.unfocusedHoverBackground": "#6e76811a",
-        "tab.border": "#30363d",
+        "tab.border": "#777777",
         "tab.unfocusedActiveBorderTop": "#30363d",
-        "tab.activeBorder": "#f78166",
-        "tab.activeModifiedBorder": "#f78166",
-        "tab.unfocusedActiveBorder": "#0d1117",
+        "tab.activeBorder": "#0d1117",
+        "tab.unfocusedActiveBorder": "#ffffff",
         "tab.activeBorderTop": "#f78166",
-        "breadcrumb.foreground": "#8b949e",
-        "breadcrumb.focusForeground": "#c9d1d9",
-        "breadcrumb.activeSelectionForeground": "#8b949e",
-        "breadcrumbPicker.background": "#161b22",
-        "editor.foreground": "#c9d1d9",
-        "editor.background": "#00205A",
-        "editorWidget.background": "#161b22",
-        "editor.foldBackground": "#6e76811a",
-        "editor.lineHighlightBackground": "#6e76811a",
-        "editorLineNumber.foreground": "#6e7681",
-        "editorLineNumber.activeForeground": "#c9d1d9",
-        "editorIndentGuide.background1": "#c9d1d91f",
-        "editorIndentGuide.activeBackground1": "#c9d1d93d",
-        "editorWhitespace.foreground": "#484f58",
-        "editorCursor.foreground": "#58a6ff",
-        "editor.findMatchBackground": "#9e6a03",
-        "editor.findMatchHighlightBackground": "#f2cc6080",
-        "editor.linkedEditingBackground": "#58a6ff12",
-        "editor.selectionHighlightBackground": "#58a6ff40",
-        "editor.wordHighlightBackground": "#6e768180",
-        "editor.wordHighlightBorder": "#6e768199",
-        "editor.wordHighlightStrongBackground": "#6e76814d",
-        "editor.wordHighlightStrongBorder": "#6e768199",
-        "editorBracketMatch.background": "#58a6ff40",
-        "editorBracketMatch.border": "#58a6ff99",
-        "editorInlayHint.background": "#8b949e33",
-        "editorInlayHint.foreground": "#8b949e",
-        "editorInlayHint.typeBackground": "#8b949e33",
-        "editorInlayHint.typeForeground": "#8b949e",
-        "editorGutter.modifiedBackground": "#bb800966",
-        "editorGutter.addedBackground": "#388bfd66",
-        "editorGutter.deletedBackground": "#d4761666",
-        "diffEditor.insertedLineBackground": "#1f6feb26",
-        "diffEditor.insertedTextBackground": "#58a6ff4d",
-        "diffEditor.removedLineBackground": "#b7610026",
-        "diffEditor.removedTextBackground": "#ec8e2c4d",
-        "scrollbar.shadow": "#484f5833",
-        "scrollbarSlider.background": "#8b949e33",
-        "scrollbarSlider.hoverBackground": "#8b949e3d",
-        "scrollbarSlider.activeBackground": "#8b949e47",
-        "editorOverviewRuler.border": "#010409",
-        "minimapSlider.background": "#8b949e33",
-        "minimapSlider.hoverBackground": "#8b949e3d",
-        "minimapSlider.activeBackground": "#8b949e47",
-        "panel.background": "#010409",
-        "panel.border": "#30363d",
-        "panelTitle.activeBorder": "#f78166",
-        "panelTitle.activeForeground": "#c9d1d9",
-        "panelTitle.inactiveForeground": "#8b949e",
-        "panelInput.border": "#30363d",
-        "debugIcon.breakpointForeground": "#d47616",
-        "debugConsole.infoForeground": "#8b949e",
-        "debugConsole.warningForeground": "#d29922",
-        "debugConsole.errorForeground": "#fdac54",
-        "debugConsole.sourceForeground": "#e3b341",
-        "debugConsoleInputIcon.foreground": "#bc8cff",
-        "debugTokenExpression.name": "#79c0ff",
-        "debugTokenExpression.value": "#a5d6ff",
-        "debugTokenExpression.string": "#a5d6ff",
-        "debugTokenExpression.boolean": "#79c0ff",
-        "debugTokenExpression.number": "#79c0ff",
-        "debugTokenExpression.error": "#fdac54",
-        "symbolIcon.arrayForeground": "#ec8e2c",
-        "symbolIcon.booleanForeground": "#58a6ff",
-        "symbolIcon.classForeground": "#ec8e2c",
-        "symbolIcon.colorForeground": "#79c0ff",
-        "symbolIcon.constructorForeground": "#d2a8ff",
-        "symbolIcon.enumeratorForeground": "#ec8e2c",
-        "symbolIcon.enumeratorMemberForeground": "#58a6ff",
-        "symbolIcon.eventForeground": "#6e7681",
-        "symbolIcon.fieldForeground": "#ec8e2c",
-        "symbolIcon.fileForeground": "#d29922",
-        "symbolIcon.folderForeground": "#d29922",
-        "symbolIcon.functionForeground": "#bc8cff",
-        "symbolIcon.interfaceForeground": "#ec8e2c",
-        "symbolIcon.keyForeground": "#58a6ff",
-        "symbolIcon.keywordForeground": "#ec8e2c",
-        "symbolIcon.methodForeground": "#bc8cff",
-        "symbolIcon.moduleForeground": "#ec8e2c",
-        "symbolIcon.namespaceForeground": "#ec8e2c",
-        "symbolIcon.nullForeground": "#58a6ff",
-        "symbolIcon.numberForeground": "#58a6ff",
-        "symbolIcon.objectForeground": "#ec8e2c",
-        "symbolIcon.operatorForeground": "#79c0ff",
-        "symbolIcon.packageForeground": "#ec8e2c",
-        "symbolIcon.propertyForeground": "#ec8e2c",
-        "symbolIcon.referenceForeground": "#58a6ff",
-        "symbolIcon.snippetForeground": "#58a6ff",
-        "symbolIcon.stringForeground": "#79c0ff",
-        "symbolIcon.structForeground": "#ec8e2c",
-        "symbolIcon.textForeground": "#79c0ff",
-        "symbolIcon.typeParameterForeground": "#79c0ff",
-        "symbolIcon.unitForeground": "#58a6ff",
-        "symbolIcon.variableForeground": "#ec8e2c",
-        "terminal.foreground": "#c9d1d9",
-        "terminal.ansiBlack": "#484f58",
-        "terminal.ansiRed": "#ec8e2c",
-        "terminal.ansiGreen": "#58a6ff",
-        "terminal.ansiYellow": "#d29922",
-        "terminal.ansiBlue": "#58a6ff",
-        "terminal.ansiMagenta": "#bc8cff",
-        "terminal.ansiCyan": "#39c5cf",
-        "terminal.ansiWhite": "#b1bac4",
-        "terminal.ansiBrightBlack": "#6e7681",
-        "terminal.ansiBrightRed": "#fdac54",
-        "terminal.ansiBrightGreen": "#79c0ff",
-        "terminal.ansiBrightYellow": "#e3b341",
-        "terminal.ansiBrightBlue": "#79c0ff",
-        "terminal.ansiBrightMagenta": "#d2a8ff",
-        "terminal.ansiBrightCyan": "#56d4dd",
-        "terminal.ansiBrightWhite": "#ffffff",
-        "editorBracketHighlight.foreground1": "#79c0ff",
-        "editorBracketHighlight.foreground2": "#79c0ff",
-        "editorBracketHighlight.foreground3": "#e3b341",
-        "editorBracketHighlight.foreground4": "#fdac54",
-        "editorBracketHighlight.foreground5": "#ff9bce",
-        "editorBracketHighlight.foreground6": "#d2a8ff",
-        "editorBracketHighlight.unexpectedBracket.foreground": "#8b949e",
-        "gitDecoration.addedResourceForeground": "#58a6ff",
-        "gitDecoration.modifiedResourceForeground": "#d29922",
-        "gitDecoration.deletedResourceForeground": "#d47616",
-        "gitDecoration.untrackedResourceForeground": "#58a6ff",
-        "gitDecoration.ignoredResourceForeground": "#6e7681",
-        "gitDecoration.conflictingResourceForeground": "#d47616",
-        "gitDecoration.submoduleResourceForeground": "#8b949e",
-        "debugToolBar.background": "#161b22",
-        "editor.stackFrameHighlightBackground": "#bb800966",
-        "editor.focusedStackFrameHighlightBackground": "#388bfd66",
-        "peekViewEditor.matchHighlightBackground": "#bb800966",
-        "peekViewResult.matchHighlightBackground": "#bb800966",
-        "peekViewEditor.background": "#6e76811a",
-        "peekViewResult.background": "#0d1117",
-        "settings.headerForeground": "#c9d1d9",
-        "settings.modifiedItemIndicator": "#bb800966",
+        "breadcrumb.foreground": "#57606a",
+        "breadcrumb.focusForeground": "#24292f",
+        "breadcrumb.activeSelectionForeground": "#57606a",
+        "breadcrumbPicker.background": "#ffffff",
+        "editor.foreground": "#24292f",
+        "editor.background": "#ffffff",
+        "editorWidget.background": "#ffffff",
+        "editor.foldBackground": "#6e77811a",
+        "editor.lineHighlightBackground": "#eaeef280",
+        "editorLineNumber.foreground": "#8c959f",
+        "editorLineNumber.activeForeground": "#24292f",
+        "editorIndentGuide.background": "#24292f1f",
+        "editorIndentGuide.activeBackground": "#24292f3d",
+        "editorWhitespace.foreground": "#afb8c1",
+        "editorCursor.foreground": "#0969da",
+        "editor.findMatchBackground": "#bf8700",
+        "editor.findMatchHighlightBackground": "#fae17d80",
+        "editor.linkedEditingBackground": "#0969da12",
+        "editor.selectionHighlightBackground": "#54aeff40",
+        "editor.wordHighlightBackground": "#eaeef280",
+        "editor.wordHighlightBorder": "#afb8c199",
+        "editor.wordHighlightStrongBackground": "#afb8c14d",
+        "editor.wordHighlightStrongBorder": "#afb8c199",
+        "editorBracketMatch.background": "#54aeff40",
+        "editorBracketMatch.border": "#54aeff99",
+        "editorInlayHint.background": "#afb8c133",
+        "editorInlayHint.foreground": "#57606a",
+        "editorInlayHint.typeBackground": "#afb8c133",
+        "editorInlayHint.typeForeground": "#57606a",
+        "editorInlayHint.paramBackground": "#afb8c133",
+        "editorInlayHint.paramForeground": "#57606a",
+        "editorGutter.modifiedBackground": "#d4a72c66",
+        "editorGutter.addedBackground": "#54aeff66",
+        "editorGutter.deletedBackground": "#f7993966",
+        "diffEditor.insertedLineBackground": "#b6e3ff4d",
+        "diffEditor.insertedTextBackground": "#80ccff80",
+        "diffEditor.removedLineBackground": "#ffddb04d",
+        "diffEditor.removedTextBackground": "#f7993966",
+        "scrollbar.shadow": "#6e778133",
+        "scrollbarSlider.background": "#8c959f33",
+        "scrollbarSlider.hoverBackground": "#8c959f3d",
+        "scrollbarSlider.activeBackground": "#8c959f47",
+        "editorOverviewRuler.border": "#ffffff",
+        "minimapSlider.background": "#8c959f33",
+        "minimapSlider.hoverBackground": "#8c959f3d",
+        "minimapSlider.activeBackground": "#8c959f47",
+        "panel.background": "#ffffff",
+        "panel.border": "#d0d7de",
+        "panelTitle.activeBorder": "#fd8c73",
+        "panelTitle.activeForeground": "#24292f",
+        "panelTitle.inactiveForeground": "#57606a",
+        "panelInput.border": "#d0d7de",
+        "debugIcon.breakpointForeground": "#b35900",
+        "debugConsole.infoForeground": "#57606a",
+        "debugConsole.warningForeground": "#7d4e00",
+        "debugConsole.errorForeground": "#b35900",
+        "debugConsole.sourceForeground": "#9a6700",
+        "debugConsoleInputIcon.foreground": "#6639ba",
+        "debugTokenExpression.name": "#0550ae",
+        "debugTokenExpression.value": "#0a3069",
+        "debugTokenExpression.string": "#0a3069",
+        "debugTokenExpression.boolean": "#0550ae",
+        "debugTokenExpression.number": "#0550ae",
+        "debugTokenExpression.error": "#8a4600",
+        "symbolIcon.arrayForeground": "#8a4600",
+        "symbolIcon.booleanForeground": "#0550ae",
+        "symbolIcon.classForeground": "#8a4600",
+        "symbolIcon.colorForeground": "#0a3069",
+        "symbolIcon.constructorForeground": "#3e1f79",
+        "symbolIcon.enumeratorForeground": "#8a4600",
+        "symbolIcon.enumeratorMemberForeground": "#0550ae",
+        "symbolIcon.eventForeground": "#57606a",
+        "symbolIcon.fieldForeground": "#8a4600",
+        "symbolIcon.fileForeground": "#7d4e00",
+        "symbolIcon.folderForeground": "#7d4e00",
+        "symbolIcon.functionForeground": "#6639ba",
+        "symbolIcon.interfaceForeground": "#8a4600",
+        "symbolIcon.keyForeground": "#0550ae",
+        "symbolIcon.keywordForeground": "#8a4600",
+        "symbolIcon.methodForeground": "#6639ba",
+        "symbolIcon.moduleForeground": "#8a4600",
+        "symbolIcon.namespaceForeground": "#8a4600",
+        "symbolIcon.nullForeground": "#0550ae",
+        "symbolIcon.numberForeground": "#0550ae",
+        "symbolIcon.objectForeground": "#8a4600",
+        "symbolIcon.operatorForeground": "#0a3069",
+        "symbolIcon.packageForeground": "#8a4600",
+        "symbolIcon.propertyForeground": "#8a4600",
+        "symbolIcon.referenceForeground": "#0550ae",
+        "symbolIcon.snippetForeground": "#0550ae",
+        "symbolIcon.stringForeground": "#0a3069",
+        "symbolIcon.structForeground": "#8a4600",
+        "symbolIcon.textForeground": "#0a3069",
+        "symbolIcon.typeParameterForeground": "#0a3069",
+        "symbolIcon.unitForeground": "#0550ae",
+        "symbolIcon.variableForeground": "#8a4600",
+        "symbolIcon.constantForeground": "#0550ae",
+        "terminal.foreground": "#24292f",
+        "terminal.ansiBlack": "#24292f",
+        "terminal.ansiRed": "#b35900",
+        "terminal.ansiGreen": "#0550ae",
+        "terminal.ansiYellow": "#4d2d00",
+        "terminal.ansiBlue": "#0969da",
+        "terminal.ansiMagenta": "#8250df",
+        "terminal.ansiCyan": "#1b7c83",
+        "terminal.ansiWhite": "#6e7781",
+        "terminal.ansiBrightBlack": "#57606a",
+        "terminal.ansiBrightRed": "#8a4600",
+        "terminal.ansiBrightGreen": "#0969da",
+        "terminal.ansiBrightYellow": "#633c01",
+        "terminal.ansiBrightBlue": "#218bff",
+        "terminal.ansiBrightMagenta": "#a475f9",
+        "terminal.ansiBrightCyan": "#3192aa",
+        "terminal.ansiBrightWhite": "#8c959f",
+        "editorBracketHighlight.foreground1": "#0969da",
+        "editorBracketHighlight.foreground2": "#0969da",
+        "editorBracketHighlight.foreground3": "#9a6700",
+        "editorBracketHighlight.foreground4": "#b35900",
+        "editorBracketHighlight.foreground5": "#bf3989",
+        "editorBracketHighlight.foreground6": "#8250df",
+        "editorBracketHighlight.unexpectedBracket.foreground": "#57606a",
+        "gitDecoration.addedResourceForeground": "#0969da",
+        "gitDecoration.modifiedResourceForeground": "#9a6700",
+        "gitDecoration.deletedResourceForeground": "#b35900",
+        "gitDecoration.untrackedResourceForeground": "#0969da",
+        "gitDecoration.ignoredResourceForeground": "#6e7781",
+        "gitDecoration.conflictingResourceForeground": "#b35900",
+        "gitDecoration.submoduleResourceForeground": "#57606a",
+        "debugToolBar.background": "#ffffff",
+        "editor.stackFrameHighlightBackground": "#d4a72c66",
+        "editor.focusedStackFrameHighlightBackground": "#54aeff66",
+        "settings.headerForeground": "#24292f",
+        "settings.modifiedItemIndicator": "#d4a72c66",
+        "welcomePage.buttonBackground": "#f6f8fa",
+        "welcomePage.buttonHoverBackground": "#f3f4f6"
     },
     "tokenColors": [
         {
@@ -250,7 +251,7 @@
                 "string.comment"
             ],
             "settings": {
-                "foreground": "#8b949e"
+                "foreground": "#6e7781"
             }
         },
         {
@@ -259,7 +260,7 @@
                 "constant.character"
             ],
             "settings": {
-                "foreground": "#ec8e2c"
+                "foreground": "#b35900"
             }
         },
         {
@@ -272,7 +273,7 @@
                 "entity"
             ],
             "settings": {
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
             }
         },
         {
@@ -282,7 +283,7 @@
                 "meta.definition.variable"
             ],
             "settings": {
-                "foreground": "#fdac54"
+                "foreground": "#8a4600"
             }
         },
         {
@@ -296,13 +297,13 @@
                 "meta.embedded.expression"
             ],
             "settings": {
-                "foreground": "#c9d1d9"
+                "foreground": "#24292f"
             }
         },
         {
             "scope": "entity.name.function",
             "settings": {
-                "foreground": "#d2a8ff"
+                "foreground": "#8250df"
             }
         },
         {
@@ -311,13 +312,13 @@
                 "support.class.component"
             ],
             "settings": {
-                "foreground": "#a5d6ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "keyword",
             "settings": {
-                "foreground": "#ec8e2c"
+                "foreground": "#b35900"
             }
         },
         {
@@ -326,7 +327,7 @@
                 "storage.type"
             ],
             "settings": {
-                "foreground": "#ec8e2c"
+                "foreground": "#b35900"
             }
         },
         {
@@ -336,7 +337,7 @@
                 "storage.type.java"
             ],
             "settings": {
-                "foreground": "#c9d1d9"
+                "foreground": "#24292f"
             }
         },
         {
@@ -345,71 +346,80 @@
                 "string punctuation.section.embedded source"
             ],
             "settings": {
-                "foreground": "#a5d6ff"
+                "foreground": "#0a3069"
             }
         },
         {
             "scope": "support",
             "settings": {
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "meta.property-name",
             "settings": {
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "variable",
             "settings": {
-                "foreground": "#fdac54"
+                "foreground": "#8a4600"
             }
         },
         {
             "scope": "variable.other",
             "settings": {
-                "foreground": "#c9d1d9"
+                "foreground": "#24292f"
             }
         },
         {
             "scope": "invalid.broken",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#fdac54"
+                "foreground": "#6f3800"
             }
         },
         {
             "scope": "invalid.deprecated",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#fdac54"
+                "foreground": "#6f3800"
             }
         },
         {
             "scope": "invalid.illegal",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#fdac54"
+                "foreground": "#6f3800"
             }
         },
         {
             "scope": "invalid.unimplemented",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#fdac54"
+                "foreground": "#6f3800"
+            }
+        },
+        {
+            "scope": "carriage-return",
+            "settings": {
+                "fontStyle": "italic underline",
+                "background": "#b35900",
+                "foreground": "#f6f8fa",
+                "content": "^M"
             }
         },
         {
             "scope": "message.error",
             "settings": {
-                "foreground": "#fdac54"
+                "foreground": "#6f3800"
             }
         },
         {
             "scope": "string variable",
             "settings": {
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
             }
         },
         {
@@ -418,7 +428,7 @@
                 "string.regexp"
             ],
             "settings": {
-                "foreground": "#a5d6ff"
+                "foreground": "#0a3069"
             }
         },
         {
@@ -429,44 +439,44 @@
                 "string.regexp string.regexp.arbitrary-repitition"
             ],
             "settings": {
-                "foreground": "#a5d6ff"
+                "foreground": "#0a3069"
             }
         },
         {
             "scope": "string.regexp constant.character.escape",
             "settings": {
                 "fontStyle": "bold",
-                "foreground": "#a5d6ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "support.constant",
             "settings": {
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "support.variable",
             "settings": {
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "support.type.property-name.json",
             "settings": {
-                "foreground": "#a5d6ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "meta.module-reference",
             "settings": {
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "punctuation.definition.list.begin.markdown",
             "settings": {
-                "foreground": "#fdac54"
+                "foreground": "#8a4600"
             }
         },
         {
@@ -476,27 +486,27 @@
             ],
             "settings": {
                 "fontStyle": "bold",
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "markup.quote",
             "settings": {
-                "foreground": "#a5d6ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "markup.italic",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#c9d1d9"
+                "foreground": "#24292f"
             }
         },
         {
             "scope": "markup.bold",
             "settings": {
                 "fontStyle": "bold",
-                "foreground": "#c9d1d9"
+                "foreground": "#24292f"
             }
         },
         {
@@ -518,7 +528,18 @@
         {
             "scope": "markup.inline.raw",
             "settings": {
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
+            }
+        },
+        {
+            "scope": [
+                "markup.deleted",
+                "meta.diff.header.from-file",
+                "punctuation.definition.deleted"
+            ],
+            "settings": {
+                "background": "#fff5e8",
+                "foreground": "#6f3800"
             }
         },
         {
@@ -526,33 +547,64 @@
                 "punctuation.section.embedded"
             ],
             "settings": {
-                "foreground": "#ec8e2c"
+                "foreground": "#b35900"
+            }
+        },
+        {
+            "scope": [
+                "markup.inserted",
+                "meta.diff.header.to-file",
+                "punctuation.definition.inserted"
+            ],
+            "settings": {
+                "background": "#ddf4ff",
+                "foreground": "#0550ae"
+            }
+        },
+        {
+            "scope": [
+                "markup.changed",
+                "punctuation.definition.changed"
+            ],
+            "settings": {
+                "background": "#ffddb0",
+                "foreground": "#8a4600"
+            }
+        },
+        {
+            "scope": [
+                "markup.ignored",
+                "markup.untracked"
+            ],
+            "settings": {
+                "foreground": "#eaeef2",
+                "background": "#0550ae"
             }
         },
         {
             "scope": "meta.diff.range",
             "settings": {
-                "foreground": "#d2a8ff",
+                "foreground": "#8250df",
                 "fontStyle": "bold"
             }
         },
         {
             "scope": "meta.diff.header",
             "settings": {
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "meta.separator",
             "settings": {
                 "fontStyle": "bold",
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
             }
         },
         {
             "scope": "meta.output",
             "settings": {
-                "foreground": "#79c0ff"
+                "foreground": "#0550ae"
             }
         },
         {
@@ -565,13 +617,13 @@
                 "brackethighlighter.quote"
             ],
             "settings": {
-                "foreground": "#8b949e"
+                "foreground": "#57606a"
             }
         },
         {
             "scope": "brackethighlighter.unmatched",
             "settings": {
-                "foreground": "#fdac54"
+                "foreground": "#6f3800"
             }
         },
         {
@@ -580,7 +632,7 @@
                 "string.other.link"
             ],
             "settings": {
-                "foreground": "#a5d6ff"
+                "foreground": "#0a3069"
             }
         }
     ]


### PR DESCRIPTION
- Updated package.json version from 1.0.10 to 1.1.0
- Added changelog entry for v1.1.0 in README.md
- Updated copilot instructions with new version and log entry
- Updated theme color definitions in super-black and super-blue themes
- Preparing for color theme improvements on fix/outdated-colors branch